### PR TITLE
BindingState is set before spawning task

### DIFF
--- a/src/client/relay_conn.rs
+++ b/src/client/relay_conn.rs
@@ -259,14 +259,13 @@ impl<T: RelayConnObserver + Send + Sync> RelayConnInternal<T> {
                     let rc_obs = Arc::clone(&self.obs);
                     let nonce = self.nonce.clone();
                     let integrity = self.integrity.clone();
-                    tokio::spawn(async move {
-                        {
-                            let mut bm = binding_mgr.lock().await;
-                            if let Some(b) = bm.get_by_addr(&bind_addr) {
-                                b.set_state(BindingState::Request);
-                            }
+                    {
+                        let mut bm = binding_mgr.lock().await;
+                        if let Some(b) = bm.get_by_addr(&bind_addr) {
+                            b.set_state(BindingState::Request);
                         }
-
+                    }
+                    tokio::spawn(async move {
                         let result = RelayConnInternal::bind(
                             rc_obs,
                             bind_addr,
@@ -321,14 +320,13 @@ impl<T: RelayConnObserver + Send + Sync> RelayConnInternal<T> {
                 let rc_obs = Arc::clone(&self.obs);
                 let nonce = self.nonce.clone();
                 let integrity = self.integrity.clone();
-                tokio::spawn(async move {
-                    {
-                        let mut bm = binding_mgr.lock().await;
-                        if let Some(b) = bm.get_by_addr(&bind_addr) {
-                            b.set_state(BindingState::Refresh);
-                        }
+                {
+                    let mut bm = binding_mgr.lock().await;
+                    if let Some(b) = bm.get_by_addr(&bind_addr) {
+                        b.set_state(BindingState::Refresh);
                     }
-
+                }
+                tokio::spawn(async move {
                     let result =
                         RelayConnInternal::bind(rc_obs, bind_addr, bind_number, nonce, integrity)
                             .await;


### PR DESCRIPTION
Setting the new BindingState before spawning the task that will process the Binding ensures that the BindingState is set as early as possible. Otherwise, there is the risk of another `send_to` spawning the same task due to reading an outdated BindingState.

Fixes https://github.com/webrtc-rs/webrtc/issues/80