### PR TITLE
update deps + loosen some requirements 

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -10,32 +10,47 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    name: Build and test
+  check_and_test:
+    name: Check and test
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        toolchain:
+          - 1.56.1 # min supported version (https://github.com/webrtc-rs/webrtc/#toolchain)
+          - stable
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
-
-  rustfmt_and_clippy:
-    name: Check rustfmt style && run clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.54.0
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  rustfmt_and_clippy:
+    name: Check rustfmt style and run clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
           profile: minimal
           components: clippy, rustfmt
           override: true
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -43,8 +58,28 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: -- -D warnings
       - name: Check formating
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+
+  minimal_versions:
+    name: Compile and test with minimal versions
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - run: cargo minimal-versions check --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions build --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions test --workspace --all-features -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,21 +14,21 @@ repository = "https://github.com/webrtc-rs/turn"
 [dependencies]
 util = { package = "webrtc-util", version = "0.5.3", default-features = false, features = ["conn", "vnet"] }
 stun = "0.4.2"
-tokio = { version = "1.15.0", features = ["full"] }
-async-trait = "0.1.52"
-log = "0.4.14"
+tokio = { version = "1.19", features = ["full"] }
+async-trait = "0.1.56"
+log = "0.4"
 base64 = "0.13.0"
-rand = "0.8.4"
+rand = "0.8.5"
 ring = "0.16.20"
-md-5 = "0.10.0"
-thiserror = "1.0.30"
+md-5 = "0.10.1"
+thiserror = "1.0"
 
 [dev-dependencies]
-tokio-test = "0.4.2"
+tokio-test = "0.4.0" # must match the min version of the `tokio` crate above
 env_logger = "0.9.0"
 chrono = "0.4.19"
 hex = "0.4.3"
-clap = "2.34.0"
+clap = "3.2.6"
 criterion = "0.3.5"
 
 [[bench]]

--- a/examples/turn_client_udp.rs
+++ b/examples/turn_client_udp.rs
@@ -104,7 +104,7 @@ async fn main() -> Result<(), Error> {
     // address assigned on the TURN server.
     println!(
         "relayed-address={}",
-        relay_conn.local_addr().await?.to_string()
+        relay_conn.local_addr().await?
     );
 
     // If you provided `-ping`, perform a ping test agaist the

--- a/src/allocation/five_tuple.rs
+++ b/src/allocation/five_tuple.rs
@@ -12,7 +12,7 @@ use std::net::{Ipv4Addr, SocketAddr};
 // server.  The 5-tuple uniquely identifies this communication
 // stream.  The 5-tuple also uniquely identifies the Allocation on
 // the server.
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct FiveTuple {
     pub protocol: Protocol,
     pub src_addr: SocketAddr,

--- a/src/client/client_test.rs
+++ b/src/client/client_test.rs
@@ -72,7 +72,7 @@ async fn test_client_with_stun_send_binding_request() -> Result<()> {
 
 #[tokio::test]
 async fn test_client_with_stun_send_binding_request_to_parallel() -> Result<()> {
-    //env_logger::init();
+    env_logger::init();
 
     let c1 = create_listening_test_client(0).await?;
     let c2 = c1.clone();

--- a/src/client/periodic_timer.rs
+++ b/src/client/periodic_timer.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TimerIdRefresh {
     Alloc,
     Perms,

--- a/src/proto/data.rs
+++ b/src/proto/data.rs
@@ -13,7 +13,7 @@ use stun::message::*;
 // and the peer).
 //
 // RFC 5766 Section 14.4
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct Data(pub Vec<u8>);
 
 impl Setter for Data {

--- a/src/proto/dontfrag.rs
+++ b/src/proto/dontfrag.rs
@@ -5,7 +5,7 @@ use stun::attributes::*;
 use stun::message::*;
 
 // DontFragmentAttr represents DONT-FRAGMENT attribute.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct DontFragmentAttr;
 
 impl Setter for DontFragmentAttr {

--- a/src/proto/evenport.rs
+++ b/src/proto/evenport.rs
@@ -13,7 +13,7 @@ use stun::message::*;
 // reserve the next-higher port number.
 //
 // RFC 5766 Section 14.6
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct EvenPort {
     // reserve_port means that the server is requested to reserve
     // the next-higher port number (on the same IP address)

--- a/src/proto/lifetime.rs
+++ b/src/proto/lifetime.rs
@@ -21,7 +21,7 @@ pub const DEFAULT_LIFETIME: Duration = Duration::from_secs(10 * 60);
 // until expiration.
 //
 // RFC 5766 Section 14.2
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct Lifetime(pub Duration);
 
 impl fmt::Display for Lifetime {

--- a/src/proto/reqtrans.rs
+++ b/src/proto/reqtrans.rs
@@ -15,7 +15,7 @@ use stun::message::*;
 // codepoint 17 (User Datagram protocol).
 //
 // RFC 5766 Section 14.7
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct RequestedTransport {
     pub protocol: Protocol,
 }

--- a/src/proto/rsrvtoken.rs
+++ b/src/proto/rsrvtoken.rs
@@ -15,7 +15,7 @@ use stun::message::*;
 // that relayed transport address for the allocation.
 //
 // RFC 5766 Section 14.9
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct ReservationToken(pub Vec<u8>);
 
 const RESERVATION_TOKEN_SIZE: usize = 8; // 8 bytes

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -59,7 +59,7 @@ impl Server {
                     relay_addr_generator: p.relay_addr_generator,
                 }));
 
-                let _ = Server::read_loop(
+                Server::read_loop(
                     p.conn,
                     allocation_manager,
                     nonces,
@@ -135,7 +135,7 @@ impl Server {
             // errors if there are no receivers, but that's irrelevant.
             let _ = tx.send(true);
             // wait for all receivers to drop/close.
-            let _ = tx.closed().await;
+            tx.closed().await;
         }
 
         Ok(())

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -765,7 +765,7 @@ impl Request {
                 MessageType::new(METHOD_CHANNEL_BIND, CLASS_SUCCESS_RESPONSE),
                 vec![Box::new(message_integrity)],
             )?;
-            return build_and_send(&self.conn, self.src_addr, msg).await;
+            build_and_send(&self.conn, self.src_addr, msg).await
         } else {
             Err(Error::ErrNoAllocationFound)
         }


### PR DESCRIPTION
rules:
- for crates that are below v1.0 -> specify the precise version
- If the code uses a feature that was added for example in X 0.3.17,
  then you should specify 0.3.17, which actually means "0.3.y where y >=
  17"
- for crates the are above or equal v1.0 -> specify only major version
  if the crate's API is minimal and won't change between minor versions
    OR specify major&minor versions otherwise

tested with https://github.com/taiki-e/cargo-minimal-versions