### PR TITLE
Add method to delete `allocation` by `username`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/webrtc-rs/turn"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+futures = "0.3.21"
 util = { package = "webrtc-util", version = "0.5.4", default-features = false, features = ["conn", "vnet"] }
 stun = "0.4.2"
 tokio = { version = "1.19", features = ["full"] }

--- a/examples/turn_client_udp.rs
+++ b/examples/turn_client_udp.rs
@@ -7,7 +7,7 @@ use tokio::net::UdpSocket;
 use tokio::time::Duration;
 use util::Conn;
 
-// RUST_LOG=trace cargo run --color=always --package webrtc-turn --example turn_client_udp -- --host 0.0.0.0 --user user=pass --ping
+// RUST_LOG=trace cargo run --color=always --package turn --example turn_client_udp -- --host 0.0.0.0 --user user=pass --ping
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {

--- a/examples/turn_server_udp.rs
+++ b/examples/turn_server_udp.rs
@@ -39,7 +39,7 @@ impl AuthHandler for MyAuthHandler {
     }
 }
 
-// RUST_LOG=trace cargo run --color=always --package webrtc-turn --example turn_server_udp -- --public-ip 0.0.0.0 --users user=pass
+// RUST_LOG=trace cargo run --color=always --package turn --example turn_server_udp -- --public-ip 0.0.0.0 --users user=pass
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {

--- a/src/allocation/allocation_manager.rs
+++ b/src/allocation/allocation_manager.rs
@@ -32,6 +32,13 @@ impl Manager {
         }
     }
 
+    pub async fn print(&self) {
+        log::error!(
+            "allocation quantity: {}",
+            self.allocations.lock().await.len()
+        );
+    }
+
     // Close closes the manager and closes all allocations it manages
     pub async fn close(&self) -> Result<()> {
         let allocations = self.allocations.lock().await;

--- a/src/allocation/allocation_manager.rs
+++ b/src/allocation/allocation_manager.rs
@@ -101,16 +101,16 @@ impl Manager {
         }
     }
 
-    /// Deletes the [`Allocation`]s according to the specified `username`.
-    pub async fn delete_allocations_by_username(&self, name: &str) {
+    /// Deletes the [`Allocation`]s containing the specified `username`.
+    pub async fn delete_allocations_by_username(&self, username: &str) {
         let to_delete = {
             let mut allocations = self.allocations.lock().await;
 
             let mut to_delete = Vec::new();
 
-            // TODO(logist322): Use `.drain_filter()` once stabilized.
+            // TODO: Use `.drain_filter()` once stabilized.
             allocations.retain(|_, allocation| {
-                let match_name = allocation.username.text == name;
+                let match_name = allocation.username.text == username;
 
                 if match_name {
                     to_delete.push(Arc::clone(allocation));

--- a/src/allocation/allocation_manager.rs
+++ b/src/allocation/allocation_manager.rs
@@ -103,6 +103,7 @@ impl Manager {
         }
     }
 
+    /// Deletes the [`Allocation`] according to the specified `username`.
     pub async fn delete_allocations_by_username(&self, name: String) {
         let mut allocations = self.allocations.lock().await;
 

--- a/src/allocation/allocation_manager.rs
+++ b/src/allocation/allocation_manager.rs
@@ -101,7 +101,7 @@ impl Manager {
         }
     }
 
-    /// Deletes the [`Allocation`] according to the specified `username`.
+    /// Deletes the [`Allocation`]s according to the specified `username`.
     pub async fn delete_allocations_by_username(&self, name: &str) {
         let to_delete = {
             let mut allocations = self.allocations.lock().await;

--- a/src/allocation/allocation_manager.rs
+++ b/src/allocation/allocation_manager.rs
@@ -32,13 +32,6 @@ impl Manager {
         }
     }
 
-    pub async fn print(&self) {
-        log::error!(
-            "allocation quantity: {}",
-            self.allocations.lock().await.len()
-        );
-    }
-
     // Close closes the manager and closes all allocations it manages
     pub async fn close(&self) -> Result<()> {
         let allocations = self.allocations.lock().await;

--- a/src/allocation/allocation_manager.rs
+++ b/src/allocation/allocation_manager.rs
@@ -108,6 +108,7 @@ impl Manager {
 
             let mut to_delete = Vec::new();
 
+            // TODO(logist322): Use `.drain_filter()` once stabilized.
             allocations.retain(|_, allocation| {
                 let match_name = allocation.username.text == name;
 

--- a/src/allocation/allocation_manager/allocation_manager_test.rs
+++ b/src/allocation/allocation_manager/allocation_manager_test.rs
@@ -357,7 +357,7 @@ async fn test_delete_allocation_by_username() -> Result<()> {
             Arc::clone(&turn_socket),
             0,
             DEFAULT_LIFETIME,
-            TextAttribute::new(ATTR_USERNAME, String::from("user2")),
+            TextAttribute::new(ATTR_USERNAME, "user2".into()),
         )
         .await?;
 
@@ -367,11 +367,9 @@ async fn test_delete_allocation_by_username() -> Result<()> {
 
     assert_eq!(m.allocations.lock().await.len(), 1);
 
-    assert!(
-        m.get_allocation(&five_tuple1).await.is_none()
-            && m.get_allocation(&five_tuple2).await.is_none()
-            && m.get_allocation(&five_tuple3).await.is_some()
-    );
+    assert!(m.get_allocation(&five_tuple1).await.is_none());
+    assert!(m.get_allocation(&five_tuple2).await.is_none());
+    assert!(m.get_allocation(&five_tuple3).await.is_some());
 
     Ok(())
 }

--- a/src/allocation/allocation_manager/allocation_manager_test.rs
+++ b/src/allocation/allocation_manager/allocation_manager_test.rs
@@ -61,7 +61,7 @@ async fn test_packet_handler() -> Result<()> {
             Arc::new(turn_socket),
             0,
             DEFAULT_LIFETIME,
-            TextAttribute::new(ATTR_USERNAME, String::from("user")),
+            TextAttribute::new(ATTR_USERNAME, "user".into()),
         )
         .await?;
 
@@ -166,7 +166,7 @@ async fn test_create_allocation_duplicate_five_tuple() -> Result<()> {
             Arc::clone(&turn_socket),
             0,
             DEFAULT_LIFETIME,
-            TextAttribute::new(ATTR_USERNAME, String::from("user")),
+            TextAttribute::new(ATTR_USERNAME, "user".into()),
         )
         .await?;
 
@@ -176,7 +176,7 @@ async fn test_create_allocation_duplicate_five_tuple() -> Result<()> {
             Arc::clone(&turn_socket),
             0,
             DEFAULT_LIFETIME,
-            TextAttribute::new(ATTR_USERNAME, String::from("user")),
+            TextAttribute::new(ATTR_USERNAME, "user".into()),
         )
         .await;
     assert!(result.is_err(), "expected error, but got ok");
@@ -201,7 +201,7 @@ async fn test_delete_allocation() -> Result<()> {
             Arc::clone(&turn_socket),
             0,
             DEFAULT_LIFETIME,
-            TextAttribute::new(ATTR_USERNAME, String::from("user")),
+            TextAttribute::new(ATTR_USERNAME, "user".into()),
         )
         .await?;
 
@@ -242,7 +242,7 @@ async fn test_allocation_timeout() -> Result<()> {
                 Arc::clone(&turn_socket),
                 0,
                 lifetime,
-                TextAttribute::new(ATTR_USERNAME, String::from("user")),
+                TextAttribute::new(ATTR_USERNAME, "user".into()),
             )
             .await?;
 
@@ -291,7 +291,7 @@ async fn test_manager_close() -> Result<()> {
             Arc::clone(&turn_socket),
             0,
             Duration::from_millis(100),
-            TextAttribute::new(ATTR_USERNAME, String::from("user")),
+            TextAttribute::new(ATTR_USERNAME, "user".into()),
         )
         .await?;
     allocations.push(a1);
@@ -302,7 +302,7 @@ async fn test_manager_close() -> Result<()> {
             Arc::clone(&turn_socket),
             0,
             Duration::from_millis(200),
-            TextAttribute::new(ATTR_USERNAME, String::from("user")),
+            TextAttribute::new(ATTR_USERNAME, "user".into()),
         )
         .await?;
     allocations.push(a2);
@@ -339,7 +339,7 @@ async fn test_delete_allocation_by_username() -> Result<()> {
             Arc::clone(&turn_socket),
             0,
             DEFAULT_LIFETIME,
-            TextAttribute::new(ATTR_USERNAME, String::from("user")),
+            TextAttribute::new(ATTR_USERNAME, "user".into()),
         )
         .await?;
     let _ = m
@@ -348,7 +348,7 @@ async fn test_delete_allocation_by_username() -> Result<()> {
             Arc::clone(&turn_socket),
             0,
             DEFAULT_LIFETIME,
-            TextAttribute::new(ATTR_USERNAME, String::from("user")),
+            TextAttribute::new(ATTR_USERNAME, "user".into()),
         )
         .await?;
     let _ = m
@@ -363,7 +363,7 @@ async fn test_delete_allocation_by_username() -> Result<()> {
 
     assert_eq!(m.allocations.lock().await.len(), 3);
 
-    m.delete_allocations_by_username(String::from("user")).await;
+    m.delete_allocations_by_username("user").await;
 
     assert_eq!(m.allocations.lock().await.len(), 1);
 

--- a/src/allocation/allocation_manager/allocation_manager_test.rs
+++ b/src/allocation/allocation_manager/allocation_manager_test.rs
@@ -62,6 +62,7 @@ async fn test_packet_handler() -> Result<()> {
             Arc::new(turn_socket),
             0,
             DEFAULT_LIFETIME,
+            String::from("user"),
         )
         .await?;
 
@@ -168,11 +169,18 @@ async fn test_create_allocation_duplicate_five_tuple() -> Result<()> {
             Arc::clone(&turn_socket),
             0,
             DEFAULT_LIFETIME,
+            String::from("user"),
         )
         .await?;
 
     let result = m
-        .create_allocation(five_tuple, Arc::clone(&turn_socket), 0, DEFAULT_LIFETIME)
+        .create_allocation(
+            five_tuple,
+            Arc::clone(&turn_socket),
+            0,
+            DEFAULT_LIFETIME,
+            String::from("user"),
+        )
         .await;
     assert!(result.is_err(), "expected error, but got ok");
 
@@ -196,6 +204,7 @@ async fn test_delete_allocation() -> Result<()> {
             Arc::clone(&turn_socket),
             0,
             DEFAULT_LIFETIME,
+            String::from("user"),
         )
         .await?;
 
@@ -231,7 +240,13 @@ async fn test_allocation_timeout() -> Result<()> {
         let five_tuple = random_five_tuple();
 
         let a = m
-            .create_allocation(five_tuple, Arc::clone(&turn_socket), 0, lifetime)
+            .create_allocation(
+                five_tuple,
+                Arc::clone(&turn_socket),
+                0,
+                lifetime,
+                String::from("user"),
+            )
             .await?;
 
         allocations.push(a);
@@ -280,6 +295,7 @@ async fn test_manager_close() -> Result<()> {
             Arc::clone(&turn_socket),
             0,
             Duration::from_millis(100),
+            String::from("user"),
         )
         .await?;
     allocations.push(a1);
@@ -290,6 +306,7 @@ async fn test_manager_close() -> Result<()> {
             Arc::clone(&turn_socket),
             0,
             Duration::from_millis(200),
+            String::from("user"),
         )
         .await?;
     allocations.push(a2);

--- a/src/allocation/allocation_test.rs
+++ b/src/allocation/allocation_test.rs
@@ -2,6 +2,7 @@ use super::*;
 
 use crate::proto::lifetime::DEFAULT_LIFETIME;
 use std::str::FromStr;
+use stun::{attributes::ATTR_USERNAME, textattrs::TextAttribute};
 use tokio::net::UdpSocket;
 
 #[tokio::test]
@@ -9,7 +10,13 @@ async fn test_has_permission() -> Result<()> {
     let turn_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
     let relay_socket = Arc::clone(&turn_socket);
     let relay_addr = relay_socket.local_addr()?;
-    let a = Allocation::new(turn_socket, relay_socket, relay_addr, FiveTuple::default());
+    let a = Allocation::new(
+        turn_socket,
+        relay_socket,
+        relay_addr,
+        FiveTuple::default(),
+        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+    );
 
     let addr1 = SocketAddr::from_str("127.0.0.1:3478")?;
     let addr2 = SocketAddr::from_str("127.0.0.1:3479")?;
@@ -40,7 +47,13 @@ async fn test_add_permission() -> Result<()> {
     let turn_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
     let relay_socket = Arc::clone(&turn_socket);
     let relay_addr = relay_socket.local_addr()?;
-    let a = Allocation::new(turn_socket, relay_socket, relay_addr, FiveTuple::default());
+    let a = Allocation::new(
+        turn_socket,
+        relay_socket,
+        relay_addr,
+        FiveTuple::default(),
+        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+    );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
     let p = Permission::new(addr);
@@ -57,7 +70,13 @@ async fn test_remove_permission() -> Result<()> {
     let turn_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
     let relay_socket = Arc::clone(&turn_socket);
     let relay_addr = relay_socket.local_addr()?;
-    let a = Allocation::new(turn_socket, relay_socket, relay_addr, FiveTuple::default());
+    let a = Allocation::new(
+        turn_socket,
+        relay_socket,
+        relay_addr,
+        FiveTuple::default(),
+        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+    );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
 
@@ -83,7 +102,13 @@ async fn test_add_channel_bind() -> Result<()> {
     let turn_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
     let relay_socket = Arc::clone(&turn_socket);
     let relay_addr = relay_socket.local_addr()?;
-    let a = Allocation::new(turn_socket, relay_socket, relay_addr, FiveTuple::default());
+    let a = Allocation::new(
+        turn_socket,
+        relay_socket,
+        relay_addr,
+        FiveTuple::default(),
+        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+    );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
     let c = ChannelBind::new(ChannelNumber(MIN_CHANNEL_NUMBER), addr);
@@ -110,7 +135,13 @@ async fn test_get_channel_by_number() -> Result<()> {
     let turn_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
     let relay_socket = Arc::clone(&turn_socket);
     let relay_addr = relay_socket.local_addr()?;
-    let a = Allocation::new(turn_socket, relay_socket, relay_addr, FiveTuple::default());
+    let a = Allocation::new(
+        turn_socket,
+        relay_socket,
+        relay_addr,
+        FiveTuple::default(),
+        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+    );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
     let c = ChannelBind::new(ChannelNumber(MIN_CHANNEL_NUMBER), addr);
@@ -139,7 +170,13 @@ async fn test_get_channel_by_addr() -> Result<()> {
     let turn_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
     let relay_socket = Arc::clone(&turn_socket);
     let relay_addr = relay_socket.local_addr()?;
-    let a = Allocation::new(turn_socket, relay_socket, relay_addr, FiveTuple::default());
+    let a = Allocation::new(
+        turn_socket,
+        relay_socket,
+        relay_addr,
+        FiveTuple::default(),
+        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+    );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
     let addr2 = SocketAddr::from_str("127.0.0.1:3479")?;
@@ -164,7 +201,13 @@ async fn test_remove_channel_bind() -> Result<()> {
     let turn_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
     let relay_socket = Arc::clone(&turn_socket);
     let relay_addr = relay_socket.local_addr()?;
-    let a = Allocation::new(turn_socket, relay_socket, relay_addr, FiveTuple::default());
+    let a = Allocation::new(
+        turn_socket,
+        relay_socket,
+        relay_addr,
+        FiveTuple::default(),
+        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+    );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
     let number = ChannelNumber(MIN_CHANNEL_NUMBER);
@@ -194,7 +237,13 @@ async fn test_allocation_refresh() -> Result<()> {
     let turn_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
     let relay_socket = Arc::clone(&turn_socket);
     let relay_addr = relay_socket.local_addr()?;
-    let mut a = Allocation::new(turn_socket, relay_socket, relay_addr, FiveTuple::default());
+    let a = Allocation::new(
+        turn_socket,
+        relay_socket,
+        relay_addr,
+        FiveTuple::default(),
+        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+    );
 
     a.start(DEFAULT_LIFETIME).await;
     a.refresh(Duration::from_secs(0)).await;
@@ -209,7 +258,13 @@ async fn test_allocation_close() -> Result<()> {
     let turn_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
     let relay_socket = Arc::clone(&turn_socket);
     let relay_addr = relay_socket.local_addr()?;
-    let mut a = Allocation::new(turn_socket, relay_socket, relay_addr, FiveTuple::default());
+    let a = Allocation::new(
+        turn_socket,
+        relay_socket,
+        relay_addr,
+        FiveTuple::default(),
+        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+    );
 
     // add mock lifetimeTimer
     a.start(DEFAULT_LIFETIME).await;

--- a/src/allocation/allocation_test.rs
+++ b/src/allocation/allocation_test.rs
@@ -15,7 +15,7 @@ async fn test_has_permission() -> Result<()> {
         relay_socket,
         relay_addr,
         FiveTuple::default(),
-        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+        TextAttribute::new(ATTR_USERNAME, "user".into()),
     );
 
     let addr1 = SocketAddr::from_str("127.0.0.1:3478")?;
@@ -52,7 +52,7 @@ async fn test_add_permission() -> Result<()> {
         relay_socket,
         relay_addr,
         FiveTuple::default(),
-        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+        TextAttribute::new(ATTR_USERNAME, "user".into()),
     );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
@@ -75,7 +75,7 @@ async fn test_remove_permission() -> Result<()> {
         relay_socket,
         relay_addr,
         FiveTuple::default(),
-        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+        TextAttribute::new(ATTR_USERNAME, "user".into()),
     );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
@@ -107,7 +107,7 @@ async fn test_add_channel_bind() -> Result<()> {
         relay_socket,
         relay_addr,
         FiveTuple::default(),
-        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+        TextAttribute::new(ATTR_USERNAME, "user".into()),
     );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
@@ -140,7 +140,7 @@ async fn test_get_channel_by_number() -> Result<()> {
         relay_socket,
         relay_addr,
         FiveTuple::default(),
-        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+        TextAttribute::new(ATTR_USERNAME, "user".into()),
     );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
@@ -175,7 +175,7 @@ async fn test_get_channel_by_addr() -> Result<()> {
         relay_socket,
         relay_addr,
         FiveTuple::default(),
-        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+        TextAttribute::new(ATTR_USERNAME, "user".into()),
     );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
@@ -206,7 +206,7 @@ async fn test_remove_channel_bind() -> Result<()> {
         relay_socket,
         relay_addr,
         FiveTuple::default(),
-        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+        TextAttribute::new(ATTR_USERNAME, "user".into()),
     );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
@@ -242,7 +242,7 @@ async fn test_allocation_refresh() -> Result<()> {
         relay_socket,
         relay_addr,
         FiveTuple::default(),
-        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+        TextAttribute::new(ATTR_USERNAME, "user".into()),
     );
 
     a.start(DEFAULT_LIFETIME).await;
@@ -263,7 +263,7 @@ async fn test_allocation_close() -> Result<()> {
         relay_socket,
         relay_addr,
         FiveTuple::default(),
-        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+        TextAttribute::new(ATTR_USERNAME, "user".into()),
     );
 
     // add mock lifetimeTimer

--- a/src/allocation/channel_bind/channel_bind_test.rs
+++ b/src/allocation/channel_bind/channel_bind_test.rs
@@ -16,7 +16,7 @@ async fn create_channel_bind(lifetime: Duration) -> Result<Allocation> {
         relay_socket,
         relay_addr,
         FiveTuple::default(),
-        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+        TextAttribute::new(ATTR_USERNAME, "user".into()),
     );
 
     let addr = SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), 0);

--- a/src/allocation/channel_bind/channel_bind_test.rs
+++ b/src/allocation/channel_bind/channel_bind_test.rs
@@ -1,16 +1,23 @@
 use super::*;
-use crate::allocation::*;
-use crate::error::Result;
+
+use crate::{allocation::*, error::Result};
 
 use tokio::net::UdpSocket;
 
 use std::net::Ipv4Addr;
+use stun::{attributes::ATTR_USERNAME, textattrs::TextAttribute};
 
 async fn create_channel_bind(lifetime: Duration) -> Result<Allocation> {
     let turn_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
     let relay_socket = Arc::clone(&turn_socket);
     let relay_addr = relay_socket.local_addr()?;
-    let a = Allocation::new(turn_socket, relay_socket, relay_addr, FiveTuple::default());
+    let a = Allocation::new(
+        turn_socket,
+        relay_socket,
+        relay_addr,
+        FiveTuple::default(),
+        TextAttribute::new(ATTR_USERNAME, String::from("user")),
+    );
 
     let addr = SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), 0);
     let c = ChannelBind::new(ChannelNumber(MIN_CHANNEL_NUMBER), addr);

--- a/src/allocation/five_tuple.rs
+++ b/src/allocation/five_tuple.rs
@@ -12,7 +12,7 @@ use std::net::{Ipv4Addr, SocketAddr};
 // server.  The 5-tuple uniquely identifies this communication
 // stream.  The 5-tuple also uniquely identifies the Allocation on
 // the server.
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone, Hash)]
 pub struct FiveTuple {
     pub protocol: Protocol,
     pub src_addr: SocketAddr,
@@ -32,12 +32,5 @@ impl Default for FiveTuple {
 impl fmt::Display for FiveTuple {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}_{}_{}", self.protocol, self.src_addr, self.dst_addr)
-    }
-}
-
-impl FiveTuple {
-    // fingerprint is the identity of a FiveTuple
-    pub fn fingerprint(&self) -> String {
-        self.to_string()
     }
 }

--- a/src/allocation/mod.rs
+++ b/src/allocation/mod.rs
@@ -12,21 +12,24 @@ use channel_bind::*;
 use five_tuple::*;
 use permission::*;
 
-use stun::agent::*;
-use stun::message::*;
+use stun::{agent::*, message::*, textattrs::Username};
 
 use util::Conn;
 
-use std::collections::HashMap;
-use std::marker::{Send, Sync};
-use std::net::SocketAddr;
-use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
-use tokio::sync::{mpsc, Mutex};
-use tokio::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    marker::{Send, Sync},
+    net::SocketAddr,
+    sync::{atomic::AtomicBool, atomic::Ordering, Arc, Mutex as StdMutex},
+};
+use tokio::{
+    sync::{mpsc, Mutex},
+    time::{Duration, Instant},
+};
 
 const RTP_MTU: usize = 1500;
 
-pub type AllocationMap = Arc<Mutex<HashMap<String, Arc<Mutex<Allocation>>>>>;
+pub type AllocationMap = Arc<Mutex<HashMap<FiveTuple, Arc<Allocation>>>>;
 
 // Allocation is tied to a FiveTuple and relays traffic
 // use create_allocation and get_allocation to operate
@@ -36,12 +39,13 @@ pub struct Allocation {
     pub(crate) relay_addr: SocketAddr,
     pub(crate) relay_socket: Arc<dyn Conn + Send + Sync>,
     five_tuple: FiveTuple,
+    username: Username,
     permissions: Arc<Mutex<HashMap<String, Permission>>>,
     channel_bindings: Arc<Mutex<HashMap<ChannelNumber, ChannelBind>>>,
     pub(crate) allocations: Option<AllocationMap>,
-    reset_tx: Option<mpsc::Sender<Duration>>,
+    reset_tx: StdMutex<Option<mpsc::Sender<Duration>>>,
     timer_expired: Arc<AtomicBool>,
-    closed: bool, // Option<mpsc::Receiver<()>>,
+    closed: AtomicBool, // Option<mpsc::Receiver<()>>,
 }
 
 fn addr2ipfingerprint(addr: &SocketAddr) -> String {
@@ -55,6 +59,7 @@ impl Allocation {
         relay_socket: Arc<dyn Conn + Send + Sync>,
         relay_addr: SocketAddr,
         five_tuple: FiveTuple,
+        username: Username,
     ) -> Self {
         Allocation {
             protocol: PROTO_UDP,
@@ -62,12 +67,13 @@ impl Allocation {
             relay_addr,
             relay_socket,
             five_tuple,
+            username,
             permissions: Arc::new(Mutex::new(HashMap::new())),
             channel_bindings: Arc::new(Mutex::new(HashMap::new())),
             allocations: None,
-            reset_tx: None,
+            reset_tx: StdMutex::new(None),
             timer_expired: Arc::new(AtomicBool::new(false)),
-            closed: false,
+            closed: AtomicBool::new(false),
         }
     }
 
@@ -174,12 +180,12 @@ impl Allocation {
     }
 
     // Close closes the allocation
-    pub async fn close(&mut self) -> Result<()> {
-        if self.closed {
+    pub async fn close(&self) -> Result<()> {
+        if self.closed.load(Ordering::Acquire) {
             return Err(Error::ErrClosed);
         }
 
-        self.closed = true;
+        self.closed.store(true, Ordering::Release);
         self.stop();
 
         {
@@ -204,9 +210,9 @@ impl Allocation {
         Ok(())
     }
 
-    pub async fn start(&mut self, lifetime: Duration) {
+    pub async fn start(&self, lifetime: Duration) {
         let (reset_tx, mut reset_rx) = mpsc::channel(1);
-        self.reset_tx = Some(reset_tx);
+        self.reset_tx.lock().unwrap().replace(reset_tx);
 
         let allocations = self.allocations.clone();
         let five_tuple = self.five_tuple.clone();
@@ -222,8 +228,7 @@ impl Allocation {
                     _ = &mut timer => {
                         if let Some(allocs) = &allocations{
                             let mut alls = allocs.lock().await;
-                            if let Some(a) = alls.remove(&five_tuple.fingerprint()) {
-                                let mut a = a.lock().await;
+                            if let Some(a) = alls.remove(&five_tuple) {
                                 let _ = a.close().await;
                             }
                         }
@@ -243,15 +248,17 @@ impl Allocation {
         });
     }
 
-    pub fn stop(&mut self) -> bool {
-        let expired = self.reset_tx.is_none() || self.timer_expired.load(Ordering::SeqCst);
-        self.reset_tx.take();
+    fn stop(&self) -> bool {
+        let mut reset_tx = self.reset_tx.lock().unwrap();
+        let expired = reset_tx.is_none() || self.timer_expired.load(Ordering::SeqCst);
+        reset_tx.take();
         expired
     }
 
     // Refresh updates the allocations lifetime
     pub async fn refresh(&self, lifetime: Duration) {
-        if let Some(tx) = &self.reset_tx {
+        let reset_tx = self.reset_tx.lock().unwrap().clone();
+        if let Some(tx) = reset_tx {
             let _ = tx.send(lifetime).await;
         }
     }
@@ -293,7 +300,7 @@ impl Allocation {
                     Err(_) => {
                         if let Some(allocs) = &allocations {
                             let mut alls = allocs.lock().await;
-                            alls.remove(&five_tuple.fingerprint());
+                            alls.remove(&five_tuple);
                         }
                         break;
                     }

--- a/src/allocation/mod.rs
+++ b/src/allocation/mod.rs
@@ -181,11 +181,9 @@ impl Allocation {
 
     // Close closes the allocation
     pub async fn close(&self) -> Result<()> {
-        if self.closed.load(Ordering::Acquire) {
+        if self.closed.swap(true, Ordering::SeqCst) {
             return Err(Error::ErrClosed);
         }
-
-        self.closed.store(true, Ordering::Release);
         self.stop();
 
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,4 @@ pub mod proto;
 pub mod relay;
 pub mod server;
 
-pub use error::{Error, Result};
+pub use error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,4 @@ pub mod proto;
 pub mod relay;
 pub mod server;
 
-pub use error::Error;
+pub use error::{Error, Result};

--- a/src/proto/chandata.rs
+++ b/src/proto/chandata.rs
@@ -35,16 +35,8 @@ impl PartialEq for ChannelData {
 }
 
 impl ChannelData {
-    // grow ensures that internal buffer will fit v more bytes and
-    // increases it capacity if necessary.
-    //
-    // Similar to stun.Message.grow method.
-    fn grow(&mut self, v: usize) {
-        let n = self.raw.len() + v;
-        self.raw.extend_from_slice(&vec![0; n - self.raw.len()]);
-    }
-
     // Reset resets Length, Data and Raw length.
+    #[inline]
     pub fn reset(&mut self) {
         self.raw.clear();
         self.data.clear();
@@ -90,7 +82,8 @@ impl ChannelData {
         if self.raw.len() < CHANNEL_DATA_HEADER_SIZE {
             // Making WriteHeader call valid even when c.Raw
             // is nil or len(c.Raw) is less than needed for header.
-            self.grow(CHANNEL_DATA_HEADER_SIZE);
+            self.raw
+                .resize(self.raw.len() + CHANNEL_DATA_HEADER_SIZE, 0);
         }
         self.raw[..CHANNEL_DATA_NUMBER_SIZE].copy_from_slice(&self.number.0.to_be_bytes());
         self.raw[CHANNEL_DATA_NUMBER_SIZE..CHANNEL_DATA_HEADER_SIZE]

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -21,7 +21,7 @@ use stun::message::*;
 // proto implements RFC 5766 Traversal Using Relays around NAT.
 
 // protocol is IANA assigned protocol number.
-#[derive(PartialEq, Eq, Default, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Default, Debug, Clone, Copy, Hash)]
 pub struct Protocol(pub u8);
 
 // PROTO_UDP is IANA assigned protocol number for UDP.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -21,7 +21,11 @@ use util::Conn;
 
 const INBOUND_MTU: usize = 1500;
 
+/// The protocol to communicate between the [`Server`]'s public methods
+/// and the threads spawned in the [`read_loop`] method.
 enum Command {
+    /// Command to delete [`crate::allocation::Allocation`] by provided
+    /// `username`.
     DeleteAllocation(String),
 }
 
@@ -159,6 +163,8 @@ impl Server {
         let _ = conn.close().await;
     }
 
+    /// Deletes the [`crate::allocation::Allocation`] by provided [`Conn`]
+    /// address and `username`.
     pub async fn delete_allocation(&self, addr: SocketAddr, username: String) {
         let commander = self.commanders.get(&addr).unwrap().lock().await;
         commander.send(Command::DeleteAllocation(username)).unwrap();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -154,8 +154,6 @@ impl Server {
                 channel_bind_timeout,
             };
 
-            allocation_manager.print().await;
-
             if let Err(err) = r.handle_request().await {
                 log::error!("error when handling datagram: {}", err);
             }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -21,7 +21,6 @@ use util::Conn;
 
 const INBOUND_MTU: usize = 1500;
 
-// #[derive(Send, Sync)]
 enum Command {
     DeleteAllocation(String),
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -31,6 +31,7 @@ enum Command {
     /// `username`.
     DeleteAllocations(String, Arc<mpsc::Receiver<()>>),
 
+    /// Command to close the [`Server`].
     Close(Arc<mpsc::Receiver<()>>),
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -57,7 +57,6 @@ impl Server {
         }
 
         for p in config.conn_configs.into_iter() {
-            log::error!("config: {:?}", p.conn.local_addr().await.unwrap());
             let nonces = Arc::clone(&s.nonces);
             let auth_handler = Arc::clone(&s.auth_handler);
             let realm = s.realm.clone();
@@ -127,8 +126,6 @@ impl Server {
                     }
                 }
             };
-
-            log::error!("address: {addr}");
 
             'commander: loop {
                 let command = commander_rx.try_recv();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -154,6 +154,8 @@ impl Server {
                 channel_bind_timeout,
             };
 
+            allocation_manager.print().await;
+
             if let Err(err) = r.handle_request().await {
                 log::error!("error when handling datagram: {}", err);
             }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -127,6 +127,8 @@ impl Server {
                 }
             };
 
+            log::error!("address: {addr}");
+
             'commander: loop {
                 let command = commander_rx.try_recv();
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -57,6 +57,7 @@ impl Server {
         }
 
         for p in config.conn_configs.into_iter() {
+            log::error!("config: {:?}", p.conn.local_addr().await.unwrap());
             let nonces = Arc::clone(&s.nonces);
             let auth_handler = Arc::clone(&s.auth_handler);
             let realm = s.realm.clone();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -120,7 +120,7 @@ impl Server {
                     match cmd {
                         Ok(Command::DeleteAllocations(name, _)) => {
                             allocation_manager
-                                .delete_allocations_by_username(name)
+                                .delete_allocations_by_username(name.as_str())
                                 .await;
                             continue;
                         }

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -157,6 +157,8 @@ impl Request {
         calling_method: Method,
     ) -> Result<Option<MessageIntegrity>> {
         log::error!("authentication start");
+        log::error!("message: {:#?}", m);
+
         if !m.contains(ATTR_MESSAGE_INTEGRITY) {
             self.respond_with_nonce(m, calling_method, CODE_UNAUTHORIZED)
                 .await?;

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -296,6 +296,8 @@ impl Request {
     pub(crate) async fn handle_binding_request(&mut self, m: &Message) -> Result<()> {
         log::debug!("received BindingRequest from {}", self.src_addr);
 
+        log::error!("message: {:#?}", m);
+
         let (ip, port) = (self.src_addr.ip(), self.src_addr.port());
 
         let msg = build_msg(

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -288,7 +288,7 @@ impl Request {
             if let Some(mi) = self.authenticate_request(m, METHOD_ALLOCATE).await? {
                 mi
             } else {
-                log::debug!("no MessageIntegrity");
+                log::debug!("no MessageIntegrity 1");
                 return Ok(());
             };
 
@@ -560,7 +560,7 @@ impl Request {
             if let Some(mi) = self.authenticate_request(m, METHOD_REFRESH).await? {
                 mi
             } else {
-                log::debug!("no MessageIntegrity");
+                log::debug!("no MessageIntegrity 2");
                 return Ok(());
             };
 
@@ -614,7 +614,7 @@ impl Request {
             {
                 mi
             } else {
-                log::debug!("no MessageIntegrity");
+                log::debug!("no MessageIntegrity 3");
                 return Ok(());
             };
             let mut add_count = 0;
@@ -730,7 +730,7 @@ impl Request {
                 if let Some(mi) = self.authenticate_request(m, METHOD_CHANNEL_BIND).await? {
                     mi
                 } else {
-                    log::debug!("no MessageIntegrity");
+                    log::debug!("no MessageIntegrity 4");
                     return Ok(());
                 };
             let mut channel = ChannelNumber::default();

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -467,6 +467,8 @@ impl Request {
         //    client to a different server.  The use of this error code and
         //    attribute follow the specification in [RFC5389].
         let lifetime_duration = allocation_lifetime(m);
+        let mut username = Username::new(ATTR_USERNAME, String::new());
+        username.get_from(m)?;
         let a = match self
             .allocation_manager
             .create_allocation(
@@ -474,6 +476,7 @@ impl Request {
                 Arc::clone(&self.conn),
                 requested_port,
                 lifetime_duration,
+                username.text,
             )
             .await
         {

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -140,7 +140,7 @@ impl Request {
         &mut self,
         m: &Message,
         calling_method: Method,
-    ) -> Result<Option<MessageIntegrity>> {
+    ) -> Result<Option<(Username, MessageIntegrity)>> {
         if !m.contains(ATTR_MESSAGE_INTEGRITY) {
             self.respond_with_nonce(m, calling_method, CODE_UNAUTHORIZED)
                 .await?;
@@ -193,7 +193,6 @@ impl Request {
             build_and_send_err(&self.conn, self.src_addr, bad_request_msg, err.into()).await?;
             return Ok(None);
         }
-
         if let Err(err) = username_attr.get_from(m) {
             build_and_send_err(&self.conn, self.src_addr, bad_request_msg, err.into()).await?;
             return Ok(None);
@@ -222,7 +221,7 @@ impl Request {
             build_and_send_err(&self.conn, self.src_addr, bad_request_msg, err.into()).await?;
             Ok(None)
         } else {
-            Ok(Some(mi))
+            Ok(Some((username_attr, mi)))
         }
     }
 
@@ -285,7 +284,7 @@ impl Request {
         //    mechanism of [https://tools.ietf.org/html/rfc5389#section-10.2.2]
         //    unless the client and server agree to use another mechanism through
         //    some procedure outside the scope of this document.
-        let message_integrity =
+        let (username, message_integrity) =
             if let Some(mi) = self.authenticate_request(m, METHOD_ALLOCATE).await? {
                 mi
             } else {
@@ -468,8 +467,6 @@ impl Request {
         //    client to a different server.  The use of this error code and
         //    attribute follow the specification in [RFC5389].
         let lifetime_duration = allocation_lifetime(m);
-        let mut username = Username::new(ATTR_USERNAME, String::new());
-        username.get_from(m)?;
         let a = match self
             .allocation_manager
             .create_allocation(
@@ -477,7 +474,7 @@ impl Request {
                 Arc::clone(&self.conn),
                 requested_port,
                 lifetime_duration,
-                username.text,
+                username,
             )
             .await
         {
@@ -513,10 +510,7 @@ impl Request {
         //     and port (from the 5-tuple).
 
         let (src_ip, src_port) = (self.src_addr.ip(), self.src_addr.port());
-        let (relay_ip, relay_port) = {
-            let a = a.lock().await;
-            (a.relay_addr.ip(), a.relay_addr.port())
-        };
+        let (relay_ip, relay_port) = { (a.relay_addr.ip(), a.relay_addr.port()) };
 
         let msg = {
             if !reservation_token.is_empty() {
@@ -557,7 +551,7 @@ impl Request {
     pub(crate) async fn handle_refresh_request(&mut self, m: &Message) -> Result<()> {
         log::debug!("received RefreshRequest from {}", self.src_addr);
 
-        let message_integrity =
+        let (_, message_integrity) =
             if let Some(mi) = self.authenticate_request(m, METHOD_REFRESH).await? {
                 mi
             } else {
@@ -575,7 +569,6 @@ impl Request {
         if lifetime_duration != Duration::from_secs(0) {
             let a = self.allocation_manager.get_allocation(&five_tuple).await;
             if let Some(a) = a {
-                let a = a.lock().await;
                 a.refresh(lifetime_duration).await;
             } else {
                 return Err(Error::ErrNoAllocationFound);
@@ -609,7 +602,7 @@ impl Request {
             .await;
 
         if let Some(a) = a {
-            let message_integrity = if let Some(mi) = self
+            let (_, message_integrity) = if let Some(mi) = self
                 .authenticate_request(m, METHOD_CREATE_PERMISSION)
                 .await?
             {
@@ -621,7 +614,6 @@ impl Request {
             let mut add_count = 0;
 
             {
-                let a = a.lock().await;
                 for attr in &m.attributes.0 {
                     if attr.typ != ATTR_XOR_PEER_ADDRESS {
                         continue;
@@ -685,15 +677,11 @@ impl Request {
 
             let msg_dst = SocketAddr::new(peer_address.ip, peer_address.port);
 
-            let has_perm = {
-                let a = a.lock().await;
-                a.has_permission(&msg_dst).await
-            };
+            let has_perm = { a.has_permission(&msg_dst).await };
             if !has_perm {
                 return Err(Error::ErrNoPermission);
             }
 
-            let a = a.lock().await;
             let l = a.relay_socket.send_to(&data_attr.0, msg_dst).await?;
             if l != data_attr.0.len() {
                 Err(Error::ErrShortWrite)
@@ -727,7 +715,7 @@ impl Request {
                 })],
             )?;
 
-            let message_integrity =
+            let (_, message_integrity) =
                 if let Some(mi) = self.authenticate_request(m, METHOD_CHANNEL_BIND).await? {
                     mi
                 } else {
@@ -753,7 +741,6 @@ impl Request {
             );
 
             let result = {
-                let a = a.lock().await;
                 a.add_channel_bind(
                     ChannelBind::new(channel, SocketAddr::new(peer_addr.ip, peer_addr.port)),
                     self.channel_bind_timeout,
@@ -788,7 +775,6 @@ impl Request {
             .await;
 
         if let Some(a) = a {
-            let a = a.lock().await;
             let channel = a.get_channel_addr(&c.number).await;
             if let Some(peer) = channel {
                 let l = a.relay_socket.send_to(&c.data, peer).await?;

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -288,7 +288,7 @@ impl Request {
             if let Some(mi) = self.authenticate_request(m, METHOD_ALLOCATE).await? {
                 mi
             } else {
-                log::debug!("no MessageIntegrity 1");
+                log::debug!("no MessageIntegrity");
                 return Ok(());
             };
 
@@ -560,7 +560,7 @@ impl Request {
             if let Some(mi) = self.authenticate_request(m, METHOD_REFRESH).await? {
                 mi
             } else {
-                log::debug!("no MessageIntegrity 2");
+                log::debug!("no MessageIntegrity");
                 return Ok(());
             };
 
@@ -614,7 +614,7 @@ impl Request {
             {
                 mi
             } else {
-                log::debug!("no MessageIntegrity 3");
+                log::debug!("no MessageIntegrity");
                 return Ok(());
             };
             let mut add_count = 0;
@@ -730,7 +730,7 @@ impl Request {
                 if let Some(mi) = self.authenticate_request(m, METHOD_CHANNEL_BIND).await? {
                     mi
                 } else {
-                    log::debug!("no MessageIntegrity 4");
+                    log::debug!("no MessageIntegrity");
                     return Ok(());
                 };
             let mut channel = ChannelNumber::default();

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -124,11 +124,26 @@ impl Request {
             }
         } else if m.typ.class == CLASS_REQUEST {
             match m.typ.method {
-                METHOD_ALLOCATE => self.handle_allocate_request(m).await,
-                METHOD_REFRESH => self.handle_refresh_request(m).await,
-                METHOD_CREATE_PERMISSION => self.handle_create_permission_request(m).await,
-                METHOD_CHANNEL_BIND => self.handle_channel_bind_request(m).await,
-                METHOD_BINDING => self.handle_binding_request(m).await,
+                METHOD_ALLOCATE => {
+                    log::error!("allocate");
+                    self.handle_allocate_request(m).await
+                }
+                METHOD_REFRESH => {
+                    log::error!("refresh");
+                    self.handle_refresh_request(m).await
+                }
+                METHOD_CREATE_PERMISSION => {
+                    log::error!("create permission");
+                    self.handle_create_permission_request(m).await
+                }
+                METHOD_CHANNEL_BIND => {
+                    log::error!("channel bind");
+                    self.handle_channel_bind_request(m).await
+                }
+                METHOD_BINDING => {
+                    log::error!("binding");
+                    self.handle_binding_request(m).await
+                }
                 _ => Err(Error::ErrUnexpectedClass),
             }
         } else {

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -156,11 +156,13 @@ impl Request {
         m: &Message,
         calling_method: Method,
     ) -> Result<Option<MessageIntegrity>> {
+        log::error!("authentication start");
         if !m.contains(ATTR_MESSAGE_INTEGRITY) {
             self.respond_with_nonce(m, calling_method, CODE_UNAUTHORIZED)
                 .await?;
             return Ok(None);
         }
+        log::error!("authentication contains");
 
         let mut nonce_attr = Nonce::new(ATTR_NONCE, String::new());
         let mut username_attr = Username::new(ATTR_USERNAME, String::new());
@@ -174,10 +176,14 @@ impl Request {
             })],
         )?;
 
+        log::error!("authentication get nonce");
+
         if let Err(err) = nonce_attr.get_from(m) {
             build_and_send_err(&self.conn, self.src_addr, bad_request_msg, err.into()).await?;
             return Ok(None);
         }
+
+        log::error!("authentication to be deleted");
 
         let to_be_deleted = {
             // Assert Nonce exists and is not expired
@@ -198,16 +204,23 @@ impl Request {
             to_be_deleted
         };
 
+        log::error!("authentication to be deleted: {}", to_be_deleted);
+
         if to_be_deleted {
             self.respond_with_nonce(m, calling_method, CODE_STALE_NONCE)
                 .await?;
             return Ok(None);
         }
 
+        log::error!("authentication realm");
+
         if let Err(err) = realm_attr.get_from(m) {
             build_and_send_err(&self.conn, self.src_addr, bad_request_msg, err.into()).await?;
             return Ok(None);
         }
+
+        log::error!("authentication username");
+
         if let Err(err) = username_attr.get_from(m) {
             build_and_send_err(&self.conn, self.src_addr, bad_request_msg, err.into()).await?;
             return Ok(None);

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -510,7 +510,8 @@ impl Request {
         //     and port (from the 5-tuple).
 
         let (src_ip, src_port) = (self.src_addr.ip(), self.src_addr.port());
-        let (relay_ip, relay_port) = { (a.relay_addr.ip(), a.relay_addr.port()) };
+        let relay_ip = a.relay_addr.ip();
+        let relay_port = a.relay_addr.port();
 
         let msg = {
             if !reservation_token.is_empty() {
@@ -677,7 +678,7 @@ impl Request {
 
             let msg_dst = SocketAddr::new(peer_address.ip, peer_address.port);
 
-            let has_perm = { a.has_permission(&msg_dst).await };
+            let has_perm = a.has_permission(&msg_dst).await;
             if !has_perm {
                 return Err(Error::ErrNoPermission);
             }

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -198,6 +198,8 @@ impl Request {
             return Ok(None);
         }
 
+        log::error!("before handle");
+
         let our_key = match self.auth_handler.auth_handle(
             &username_attr.to_string(),
             &realm_attr.to_string(),
@@ -205,6 +207,7 @@ impl Request {
         ) {
             Ok(key) => key,
             Err(_) => {
+                log::error!("error");
                 build_and_send_err(
                     &self.conn,
                     self.src_addr,
@@ -215,6 +218,8 @@ impl Request {
                 return Ok(None);
             }
         };
+
+        log::error!("after handle");
 
         let mi = MessageIntegrity(our_key);
         if let Err(err) = mi.check(&mut m.clone()) {

--- a/src/server/request/request_test.rs
+++ b/src/server/request/request_test.rs
@@ -92,7 +92,7 @@ async fn test_allocation_lifetime_deletion_zero_lifetime() -> Result<()> {
             Arc::clone(&r.conn),
             0,
             Duration::from_secs(3600),
-            TextAttribute::new(ATTR_USERNAME, String::from("user")),
+            TextAttribute::new(ATTR_USERNAME, "user".into()),
         )
         .await?;
     assert!(r

--- a/src/server/request/request_test.rs
+++ b/src/server/request/request_test.rs
@@ -1,13 +1,12 @@
 use super::*;
 use crate::relay::relay_none::*;
 
+use std::{net::IpAddr, str::FromStr};
+use tokio::{
+    net::UdpSocket,
+    time::{Duration, Instant},
+};
 use util::vnet::net::*;
-
-use std::net::IpAddr;
-use std::str::FromStr;
-
-use tokio::net::UdpSocket;
-use tokio::time::{Duration, Instant};
 
 const STATIC_KEY: &str = "ABC";
 
@@ -93,7 +92,7 @@ async fn test_allocation_lifetime_deletion_zero_lifetime() -> Result<()> {
             Arc::clone(&r.conn),
             0,
             Duration::from_secs(3600),
-            String::from("user"),
+            TextAttribute::new(ATTR_USERNAME, String::from("user")),
         )
         .await?;
     assert!(r

--- a/src/server/request/request_test.rs
+++ b/src/server/request/request_test.rs
@@ -93,6 +93,7 @@ async fn test_allocation_lifetime_deletion_zero_lifetime() -> Result<()> {
             Arc::clone(&r.conn),
             0,
             Duration::from_secs(3600),
+            String::from("user"),
         )
         .await?;
     assert!(r


### PR DESCRIPTION
## Synopsis

We are currently trying to replace [Coturn](https://github.com/coturn/coturn) with this implementation. But currently it does not have alternatives to specific Coturn's functionality e.g. providing metrics, TCP fallback, external management capabilities. So we want to elaborate on that starting with exposing some management interfaces. 

Here is the Coturn's telnet protocol for reference:

```
TURN Server
Coturn-4.5.2 'dan Eider'

  ?, h, help - print this text

  quit, q, exit, bye - end CLI session

  stop, shutdown, halt - shutdown TURN Server

  pc - print configuration

  sr <realm> - set CLI session realm

  ur - unset CLI session realm

  so <origin> - set CLI session origin

  uo - unset CLI session origin

  tc <param-name> - toggle a configuration parameter
     (see pc command output for togglable param names)

  cc <param-name> <param-value> - change a configuration parameter
     (see pc command output for changeable param names)

  ps [username] - print sessions, with optional exact user match

  psp <usernamestr> - print sessions, with partial user string match

  psd <file-name> - dump ps command output into file on the TURN server system

  pu [udp|tcp|dtls|tls]- print current users

  lr - log reset

  aas ip[:port} - add an alternate server reference
  das ip[:port] - delete an alternate server reference
  atas ip[:port] - add a TLS alternate server reference
  dtas ip[:port] - delete a TLS alternate server reference

  cs <session-id> - cancel session, forcefully

```

The particular function that we need is being able to forcefully close specific allocations.

## Solution

Add the ability to communicate with the applications main loop, running in the `Server::read_loop()` method.

Add `Server.delete_allocations_by_username(&self, username: String)` function.

Also, there are some low-hanging fruits in terms of optimizations, so this pull request includes minor refactoring aimed at improving overall performance.